### PR TITLE
Test for FREQM parsing problem.

### DIFF
--- a/src/test/java/us/gov/dod/standard/ssrf/_3_1/adapter/types/XmlAdapterFREQMTest.java
+++ b/src/test/java/us/gov/dod/standard/ssrf/_3_1/adapter/types/XmlAdapterFREQMTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package us.gov.dod.standard.ssrf._3_1.adapter.types;
+
+import static junit.framework.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ * Unit tests for FREQM serialisation.
+ *
+ * @author Brad Hards (bradh@frogmouth.net)
+ */
+public class XmlAdapterFREQMTest {
+
+  public XmlAdapterFREQMTest() {
+  }
+
+  @Test
+  public void testMarshal() throws Exception {
+    System.out.println("Test Marshal");
+    XmlAdapterFREQM adapterFREQM = new XmlAdapterFREQM();
+
+    for (Number number : new Number[] { 123.456, 0.1 }) {
+        String freq = adapterFREQM.marshal(number);
+        System.out.println("  " + number + " marshals to " + freq);
+        assertEquals(number.doubleValue(), Double.parseDouble(freq));
+    }
+  }
+
+}


### PR DESCRIPTION
This demonstrates marshalling of doubles less than 1 in AXmlAdapterNumber, which
turns out to be a problem for small bandwidth values.
